### PR TITLE
Support pour utilisation en tant que macro `{{ sqlide(...) }}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /mkdocs_sqlite_console.egg-info/
 /venv/
 /build/
-
+**/.vscode
 **/__pycache__/
 
 .DS_Store

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,10 +9,31 @@ plugins:
   - sqlite-console
 ```
 
-!!! note 
-    Si vous n'avez aucune entrée dans la section `plugins` de votre fichier de configuration, 
-    vous voudrez sans doute ajouter le plugin `search`. MkDocs l'active par défaut s'il n'y a pas 
+!!! note
+    Si vous n'avez aucune entrée dans la section `plugins` de votre fichier de configuration,
+    vous voudrez sans doute ajouter le plugin `search`. MkDocs l'active par défaut s'il n'y a pas
     d'autres `plugins`, et dans le cas contraire, MkDocs demande de l'activer explicitement.
+
+!!! note "Utilisation avec `mkdocs-macros-plugin` ou Pyodide-MkDocs-Theme"
+
+    Noter que le plugin `mkdocs-sqlite-console` doit toujours être référencé après les plugins de PMT ou des macros, dans le fichier `mkdocs.yml` :
+
+    ```yaml
+    plugins:
+        - search
+        - macros            # avec mkdocs-macros-plugin
+        - sqlite-console
+    ```
+
+    ```yaml
+    plugins:
+        - search
+        - pyodide_macros    # avec PMT
+        - sqlite-console
+    ```
+
+
+
 
 Si vous voulez déployer votre site (à l'aide de `mkdocs build` ou `mkdocs gh-deploy`), il faut également ajouter à votre
 fichier `mkdocs.yml` une ligne du type
@@ -25,7 +46,7 @@ site_url: https://epithumia.github.io/mkdocs-sqlite-console
 ```
 
 !!! error "site_url"
-    Si vous n'avez pas défini la variable `site_url` dans votre fichier `mkdocs.yml`, les commandes 
+    Si vous n'avez pas défini la variable `site_url` dans votre fichier `mkdocs.yml`, les commandes
     `mkdocs build` et `mkdocs gh-deploy` ne fonctionneront pas et signaleront la nécessité de le faire.
 
 ## Afficher la console/IDE
@@ -46,7 +67,9 @@ On peut afficher une console/IDE SQLite grâce à la commande `{{ sqlide paramè
     - le titre *doit* être entre guillemets
     - les chemins vers les fichiers sont relatifs à la racine du site
     - les chemins ne peuvent pas contenir d'espace
-    - les options base et init sont mutuellement exclusives ; l'option base est prioritaire. 
+    - les options base et init sont mutuellement exclusives ; l'option base est prioritaire.
+
+    Voir le cas des [utilisations en tant que macro](#as-macros), où les syntaxes diffèrent légèrement.
 
 ### Quelques exemples
 
@@ -77,7 +100,7 @@ Si l'on ne veut que le résultat de la requête sans pour autant afficher l'IDE,
 {{sqlide titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté, IDE caché" base="bases/test.db" sql="sql/code.sql" autoexec hide}}
 ```
 
-{{sqlide titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté, IDE caché" base="bases/test.db" sql="sql/code.sql" autoexec hide}}
+{{sqlide(titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté, IDE caché" base="bases/test.db" sql="sql/code.sql" autoexec hide)}}
 
 !!! warning "Titre"
     Attention, le titre n'est plus affiché dans ce cas.
@@ -130,20 +153,84 @@ donne
     ??? sql "Bloc admonition avec initialisation et code pré-saisi"
         {{ sqlide titre="Init + Code" init="sql/init1.sql" sql="sql/code.sql" }}
 
-### Usage avec le plugin [macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/)
 
-Le plugin macros utilise les doubles accolades pour définir ses propres blocs de code, ce qui empêche ce plugin de 
-fonctionner normalement. En conséquence, quand le plugin macros est détecté, la syntaxe change et l'IDE SQLite est
-chargée avec la syntaxe suivante :
+
+
+## Usage avec le plugin [macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) ou [Pyodide-MkDocs-Theme](https://frederic-zinelli.gitlab.io/pyodide-mkdocs-theme/) { #as-macros }
+
+
+`mkdocs-sqlite-console` est compatible avec l'utilisation du plugin `mkdocs-macros`, ainsi que le thème Pyodide-MkDocs-Theme.
+
+Si l'un des deux est utilisé (avec une manipulation de configuration à faire pour le plugin des macros seul), il est alors possible de déclarer un `sqlide` via un appel de macro :
+
 ```markdown
-{!{ sqlide paramètres }!}
+{{ sqlide(titre="Init + Code", init="sql/init1.sql", sql="sql/code.sql") }}
 ```
-Par exemple `{!{ sqlide titre="IDE avec initialisation et code pré-saisi" init="sql/init1.sql" sql="sql/code.sql" }!}`
-affichera :
 
-{{ sqlide titre="IDE avec initialisation et code pré-saisi" init="sql/init1.sql" sql="sql/code.sql" }}
+### Syntaxes
 
-### Erreurs
+Par rapport à l'utilisation normale du plugin, il faut :
+
+* Ajouter les parenthèses autour des arguments,
+* Ajouter des virgules entre les arguments,
+* Les guillemets autour des valeurs des arguments sont alors indispensables.
+
+
+
+??? tip "Anciennes syntaxes - versions 1.0.7 et antérieures"
+
+    _Ceci décrit les anciens comportements pour utiliser `mkdocs-sqlite-console` avec le plugin des macros ou PMT activés.
+    Ces méthodes restent utilisables._
+    { style="color:#FFAA00" }
+
+    Le plugin `macros` utilise les doubles accolades pour définir ses propres blocs de code, ce qui empêche ce plugin de
+    fonctionner normalement. En conséquence, quand le plugin macros est détecté, la syntaxe change et l'IDE SQLite est
+    chargée avec la syntaxe suivante :
+
+    ```markdown
+    {!{ sqlide paramètres }!}
+    ```
+
+    Par exemple, l'appel :
+
+    ```markdown
+    {{ sqlide titre="..." init="sql/init1.sql" sql="sql/code.sql" }}
+    ```
+
+    ...devait alors s'écrire :
+
+    `{!{ sqlide titre="..." init="sql/init1.sql" sql="sql/code.sql" }!}`
+
+
+
+### Activation
+
+#### Pyodide-MkDocs-Theme
+
+Le thème gère tout automatiquement, à partir de sa version 4.4.5.
+
+Les versions antérieures nécessitent d'utiliser les anciennes syntaxes de déclaration des `sqlide`.
+
+
+#### `mkdocs-macros-plugin`
+
+Dans le cas d'utilisation du plugin des macros seul, il est nécessaire d'enregistrer la macro depuis votre fichier/module de macros personnalisées.
+Par défaut, il s'agit du fichier `main.py` :
+
+```python
+
+def define_env(env):
+
+    # Vos macros personnalisées ici:
+    ...
+
+    # Enregistrement de la macro sqlide:
+    sql_plugin = env._conf.plugins['sqlite-console']
+    env.macro(sql_plugin.sqlide)
+```
+
+
+## Erreurs
 
 Le plugin détectera les fichiers non existants :
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
-# Logistique pour tester en local avec l'utilisation de mkdocs-macros-plugin.
-#
-# Nécessite d'installer le plugin dans le venv et de configurer mkdocs.yml.plugins.macros
+"""
+Logistique pour tester en local avec l'utilisation de mkdocs-macros-plugin.
 
+Nécessite d'installer le plugin dans le venv et d'ajouter le plugin macros
+dans mkdocs.yml:plugins.
+"""
 
 def define_env(env):
-    env.macro(env._conf.plugins['sqlite-console'].sqlide)
+    sql_plugin = env._conf.plugins['sqlite-console']
+    env.macro(sql_plugin.sqlide)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+# Logistique pour tester en local avec l'utilisation de mkdocs-macros-plugin.
+#
+# Nécessite d'installer le plugin dans le venv et de configurer mkdocs.yml.plugins.macros
+
+
+def define_env(env):
+    env.macro(env._conf.plugins['sqlite-console'].sqlide)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,8 @@ theme:
 
 nav:
     - Home: 'index.md'
-    - 'Guide d''utilisation': 'usage.md'
-    - A propos:
+    - Guide d'utilisation: 'usage.md'
+    - À propos:
         - 'License': 'licence.md'
         - 'Historique des versions': 'notes-de-version.md'
 
@@ -22,10 +22,11 @@ edit_uri: edit/main/docs/
 
 plugins:
   - search
-  # - macros          # pour tester en local. A déclarer avant sqlite-console.
+  # - macros          # Activer pour tester en local (Nota: à placer avant sqlite-console)
   - sqlite-console
 
 markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ edit_uri: edit/main/docs/
 
 plugins:
   - search
+  # - macros          # pour tester en local. A déclarer avant sqlite-console.
   - sqlite-console
 
 markdown_extensions:

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -141,13 +141,7 @@ class SQLiteConsole(BasePlugin):
         self.has_instant_nav ='navigation.instant' in config["theme"]["features"]
 
         plugins = config['plugins']
-        if 'pyodide_macros' in plugins or 'macros' in plugins:
-
-            # Register the PMT/macros plugin
-            self.macros = plugins.get('pyodide_macros') or plugins['macros']
-
-            # Register as macro, to use as: `{{ sqlide(titre=..., ...) }}`
-            self.macros.macro(self.sqlide)      # The name of the method defines the macro name
+        self.macros = plugins.get('pyodide_macros') or plugins.get('macros')
 
         return config
 
@@ -231,6 +225,10 @@ class SQLiteConsole(BasePlugin):
         sql = None,
         space = None,
     ):
+        """
+        Can be registered as a mkdocs macro (through the macro module, or automatically
+        when using PMT).
+        """
         # (actual default values are handled in Counter.build_sql)
         c = self.counter_for(self.macros.page)
-        c.build_sql(titre, autoexec, hide, init, base, sql, space)
+        return c.build_sql(titre, autoexec, hide, init, base, sql, space)

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -181,29 +181,28 @@ class SQLiteConsole(BasePlugin):
         return html
 
 
-    def on_post_page(self, out: str, page: Page, config, **kwargs):
+    def on_page_context(self, ctx, page: Page, config, **kwargs):
 
         c = self.counter_for(page)
 
         # When using navigation.instant, the scripts are loaded once only and have to always
         # be included in every page (because one doesn't know where the user will land first)
-        if not self.has_instant_nav and (not c or not c.count):
-            return out      # No ressources needed for this page (without navigation.instant)
+        if self.has_instant_nav or c and c.count:
 
-        base_url = config['site_url']
-        codemirror = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.js"
-        codemirror_css = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.css"
-        codemirror_sql = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/mode/sql/sql.min.js"
+            base_url = config['site_url']
+            codemirror     = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.js"
+            codemirror_css = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.css"
+            codemirror_sql = "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/mode/sql/sql.min.js"
 
-        out = out.replace("</title>", f"""</title>
+            sql_scripts = f"""\
 <script src="{ codemirror }"></script>
 <script src="{ base_url }/js/sqlite_ide.js"></script>
 <script src="{ codemirror_sql }"></script>
 <link rel="stylesheet" href="{ codemirror_css }">
 <link rel="stylesheet" href="{ base_url }/css/sqlite_ide.css">
 <script>path="{ base_url }"</script>
-""")
-        return out
+"""
+            page.content = sql_scripts + page.content
 
 
 


### PR DESCRIPTION
Ferme #6 , #7, concerne aussi #5 

* les scripts sont injectés via `on_page_context` (ajoutés au début de `page.content`, qui contient le contenu de la balise `<body>`, dans les grandes lignes)
* Les scripts ne sont ajoutés aux pages que si nécessaire, lorsque `theme.feature; navigation.instant` n'est pas activée
* Les anciennes syntaxes `{!{ ... }!}` sont toujours supportées quand les macros sont activées.
* Possibilité d'utiliser `{{ sqlide(titre="...", ...) }}` en tant que macro jinja/mkdocs
* MAJ de la doc pour expliquer les nouveaux comportements + comment les activer (MAJ manuelle pour le plugin des macros seul / Il faudra que je fasse la MAJ côté PMT encore... Et c'est pas gagné car en fin de compte, je n'ai plus de PC fix... Et je n'ai jamais réussi à publier une MAJ sur PyPI depuis le portable. Ce sera l'occasion de chercher... :roll_eyes: )
* Qqes modifs ici ou là...