### PR TITLE
FIXes pour la v2.0.1

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,13 +52,15 @@ site_url: https://epithumia.github.io/mkdocs-sqlite-console
 
 ## Afficher la console/IDE
 
+### Paramètres
+
 On peut afficher une console/IDE SQLite grâce à la commande `{{ sqlide paramètres }}`. Cette commande accepte quatre paramètres, tous optionnels :
 
-- un *titre* : par exemple `titre="Exercice 1"`. Par défaut, le titre est "sql"
-- un chemin vers un script SQL d'initialisation *init* : par exemple `init=sql/init.md`
-- un chemin vers une *base* SQLite : par exemple `bases/test.db`
-- un chemin vers un fichier de code *sql* pré-saisi dans l'IDE : par exemple `sql="sql/code.sql"`
-- si le mot clef *autoexec* est présent, alors le contenu de code sera exécuté comme si l'utilisateur avit cliqué le bouton
+- un `titre` : par exemple `titre="Exercice 1"`. Par défaut, le titre est "sql"
+- un chemin vers un script SQL d'initialisation, `init` : par exemple `init=sql/init.md`
+- un chemin vers une `base` SQLite : par exemple `bases/test.db`
+- un chemin vers un fichier de code `sql` pré-saisi dans l'IDE : par exemple `sql="sql/code.sql"`
+- si le mot clef `autoexec` est présent, alors le contenu de code sera exécuté comme si l'utilisateur avait cliqué le bouton
 
 !!! tip "Astuce"
     A part pour le titre, les apostrophes ou guillemets sont optionnels. Ainsi, `sql="sql/code.sql"`,
@@ -155,9 +157,9 @@ donne :
     ??? sql "Bloc admonition avec initialisation et code pré-saisi"
         {{ sqlide titre="Init + Code" init="sql/init1.sql" sql="sql/code.sql" }}
 
-## Usage avec le plugin [macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) ou [Pyodide-MkDocs-Theme](https://frederic-zinelli.gitlab.io/pyodide-mkdocs-theme/) { #as-macros }
+## Usage avec le plugin des macros MkDocs ou Pyodide-MkDocs-Theme { #as-macros }
 
-`mkdocs-sqlite-console` est compatible avec l'utilisation du plugin `mkdocs-macros`, ainsi que le thème Pyodide-MkDocs-Theme.
+`mkdocs-sqlite-console` est compatible avec l'utilisation du plugin [`mkdocs-macros-plugin`](https://mkdocs-macros-plugin.readthedocs.io/en/latest/), ainsi que le thème [Pyodide-MkDocs-Theme](https://frederic-zinelli.gitlab.io/pyodide-mkdocs-theme/).
 
 Si l'un des deux est utilisé (avec une manipulation de configuration à faire pour le plugin des macros seul), il est alors possible de déclarer un `sqlide` via un appel de macro :
 
@@ -172,6 +174,40 @@ Par rapport à l'utilisation normale du plugin, il faut :
 - Ajouter les parenthèses autour des arguments,
 - Ajouter des virgules entre les arguments,
 - Les guillemets autour des valeurs des arguments sont alors indispensables.
+- Les arguments passés sous forme de chaînes de caractères seule, dans la syntaxe originale (`autoexec`, `hide`), doivent être passés sous forme de booléens. On peut aussi utiliser des entiers pour raccourcir les déclaration : `0` ou `1`.
+
+??? help "Signature exacte de la macro"
+
+    Voici la déclaration exacte de la macro, et les valeurs par défaut associées aux différents arguments :
+
+    ```python
+    sqlide(
+        self,
+        titre='Sql',
+        sql='',
+        espace=None,
+        *,
+        base='/',
+        init='',
+        hide=False,
+        autoexec=False,
+    )
+    ```
+
+    * Les trois premiers arguments, `titre`, `sql` et `espace` sont des arguments positionnels avec des valeurs par défaut : il n'est pas obligatoire de mettre le nom de l'argument (mais dans ce cas, il faut respecter l'ordre de déclaration).
+
+    * Les arguments après `*,` sont des arguments nommés. Ils doivent impérativement être renseignés en précisant le nom de l'argument.
+
+    * Il est toujours possible de renseigner les noms des arguments positionnels si on le souhaite (dans ce cas, il n'est pas indispensable de respecter leur ordre dans la déclaration).
+
+    <br>
+
+    L'appel de l'exemple ci-dessus peut donc également se faire comme suit :
+
+
+    ```markdown
+    {{ sqlide("Init + Code", "sql/code.sql", init="sql/init1.sql") }}
+    ```
 
 ??? tip "Anciennes syntaxes - versions 1.0.7 et antérieures"
 
@@ -199,15 +235,16 @@ Par rapport à l'utilisation normale du plugin, il faut :
 
 ### Activation
 
-#### Pyodide-MkDocs-Theme
+#### `Pyodide-MkDocs-Theme`
 
 Le thème gère tout automatiquement, à partir de sa version 4.4.6.
 
-Les versions antérieures nécessitent d'utiliser les anciennes syntaxes de déclaration des `sqlide`.
+Les versions antérieures nécessitent d'utiliser les anciennes syntaxes de déclaration des `sqlide`, ou de mettre en place la logistique décrite ci-dessous pour `mkdocs-macros-plugin`.
 
 #### `mkdocs-macros-plugin`
 
-Dans le cas d'utilisation du plugin des macros seul, il est nécessaire d'enregistrer la macro depuis votre fichier/module de macros personnalisées.
+Dans le cas de l'utilisation du plugin des macros seul, il est nécessaire d'enregistrer la macro depuis votre fichier/module de macros personnalisées.
+
 Par défaut, il s'agit du fichier `main.py` :
 
 ```python

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -16,8 +16,9 @@ CSS_PATH = BASE_PATH + "/css/"
 
 JS_PATH = BASE_PATH + "/js/"
 
+
+# "{workerinit}" was the first line of the template: removed in version > 2.0.0.
 SKELETON = """
-{workerinit}
 <div id="ide{numide}" {hide}>
 <label for='sqlcommands'>{title}</label>
 <br>
@@ -32,7 +33,10 @@ SKELETON = """
     load(ide, '{base}', '{init}', '{autoexec}', {worker});
 }}).catch(() => {{}});
 </script>
-"""
+""".strip()     # Stripping necessary for use as macro (indentation has to be worked out...)
+
+MACROS_TEMPLATE = "MKDOCS_SQLITE_CONSOLE_IDE_{}"
+
 
 
 class Counter:
@@ -40,6 +44,8 @@ class Counter:
         self.count = 0
         self.config = config
         self.spaces = {}
+        self.macros_contents = {}
+        self.worker_inits = []
 
     def insert_ide(self, macro):
         regex_titre = r".*?titre=\"(.*?)\""
@@ -73,17 +79,16 @@ class Counter:
         space = space or None
 
         worker = ""
-        workerinit = ""
         if space:
             if space not in self.spaces:
                 self.spaces[space] = 0
-                workerinit = '<script>var {worker} = new Worker(sqljs_base_path + "/js/worker.sql-wasm.js");</script>'.format(
+                workerinit = 'var {worker} = new Worker(sqljs_base_path + "/js/worker.sql-wasm.js");'.format(
                     worker=space
                 )
+                self.worker_inits.append(workerinit)
                 worker = space
             else:
                 self.spaces[space] += 1
-                workerinit = ""
                 worker = space
         if sql != "":
             try:
@@ -115,7 +120,7 @@ class Counter:
                 sql = "-- Fichier de base '" + base + "' introuvable"
                 init = ""
                 base = "/"
-        return SKELETON.format(
+        html = SKELETON.format(
             numide=self.count,
             title=titre,
             hide=hide,
@@ -124,8 +129,35 @@ class Counter:
             init=init,
             autoexec=autoexec,
             worker=worker,
-            workerinit=workerinit,
+            #workerinit=workerinit,      # Not inserted here anymore (version > 2.0.0)
         )
+        return html
+
+    def register_macro_content(self, html_code):
+        """
+        Store the html code generated from the macro call, to insert it later (in on_page_content
+        hook: this avoids rendering troubles of the SQL code provided by the user, when mkdocs
+        renders md to html: the user's code is in `<pre>` tags, so the line breaks have to be
+        kept "as they are".
+        """
+        token = MACROS_TEMPLATE.format(self.count)
+        self.macros_contents[token] = html_code
+        return token
+
+    def insert_macro_contents(self, html):
+        """ To do _before_ resolving the older syntaxes. """
+        if self.count:
+            html = re.sub(
+                MACROS_TEMPLATE.format('\\d+'),
+                lambda m: self.macros_contents[m[0]],
+                html,
+            )
+        return html
+
+    def get_worker_inits(self):
+        workers = " ".join(self.worker_inits)
+        return f"<script>{ workers }</script>"
+
 
 
 # noinspection PyUnusedLocal
@@ -174,26 +206,34 @@ class SQLiteConsole(BasePlugin):
         # NOTE: regex are working on the interpreted markdown, so searching for `<p>...</p>` to
         #       not match calls that are in code blocks, in the documentation.
 
+        c = self.counter_for(page)
         if self.macros:
+            # Insert code coming from the macro use itself (done now to avoid rendering troubles
+            # when converting md 6> html after the macro content was inserted):
+            # To apply BEFORE using the old syntax logistic (relies on c.count value).god cod
+            html = c.insert_macro_contents(html)
+
             # Still apply the "old way", for backward compatibility.
             # If used as an actual macro, this won't find anything to update in the page.
             regex = r"(?:^|\n)\s*?<p>\s*?{!{\s*?sqlide.*?\s+?(.*?)\s*?}!}</p>(?:\n|$)"
         else:
             regex = r"(?:^|\n)\s*?<p>\s*?{{\s*?sqlide.*?\s+?(.*?)\s*?}}</p>(?:\n|$)"
 
-        c = self.counter_for(page)
         if c:
             html = re.sub(regex, c.insert_ide, html, flags=re.MULTILINE | re.DOTALL)
 
         return html
 
-    def on_page_context(self, ctx, page: Page, config, **kwargs):
+    def on_page_context(self, ctx, page:Page, config, **kwargs):
 
         c = self.counter_for(page)
+        sql_scripts = ""
+        is_page_with_sql_ides = bool(c and c.count)
 
         # When using navigation.instant, the scripts are loaded once only and have to always
-        # be included in every page (because one doesn't know where the user will land first)
-        if self.has_instant_nav or c and c.count:
+        # be included in every page (because one doesn't know where the user will land first).
+        # If no navigation.instant, they have to be inserted in all pages using sql IDEs.
+        if self.has_instant_nav or is_page_with_sql_ides:
 
             base_url = config["site_url"]
             codemirror = (
@@ -210,6 +250,18 @@ class SQLiteConsole(BasePlugin):
 <link rel="stylesheet" href="{ base_url }/css/sqlite_ide.css">
 <script>sqljs_base_path="{ base_url }"</script>
 """
+
+        # If some sqlides are used in the page, insert the workers logistic:
+        # NOTES:
+        #   1. This depends on the page content, and is not related to navigation.instant
+        #   2. The workers have to be inserted once per page, depending on the number of "spaces"
+        #   3. They have to be inserted _after_ the sql scripts...
+        #   4. ...but _before_ any SQL IDE in the html.
+        if is_page_with_sql_ides:
+            sql_scripts += c.get_worker_inits()
+
+        # Mutate the page content with all the required logistic if any:
+        if sql_scripts:
             page.content = sql_scripts + page.content
 
     def counter_for(self, page, *, set_counter: Counter = None) -> Optional[Counter]:
@@ -222,17 +274,19 @@ class SQLiteConsole(BasePlugin):
     def sqlide(
         self,
         titre=None,
-        autoexec=None,
-        hide=None,
-        init=None,
-        base=None,
         sql=None,
         espace=None,
+        *,
+        base=None,
+        init=None,
+        hide=None,
+        autoexec=None,
     ):
         """
         Can be registered as a mkdocs macro (through the macro module, or automatically
-        when using PMT).
+        when using Pyodide-MkDocs-Theme).
         """
         # (actual default values are handled in Counter.build_sql)
         c = self.counter_for(self.macros.page)
-        return c.build_sql(titre, autoexec, hide, init, base, sql, espace)
+        html_code = c.build_sql(titre, autoexec, hide, init, base, sql, espace)
+        return c.register_macro_content(html_code)

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -33,7 +33,7 @@ SKELETON = """
     load(ide, '{base}', '{init}', '{autoexec}', {worker});
 }}).catch(() => {{}});
 </script>
-""".strip()     # Stripping necessary for use as macro (indentation has to be worked out...)
+"""
 
 MACROS_TEMPLATE = "MKDOCS_SQLITE_CONSOLE_IDE_{}"
 
@@ -210,7 +210,7 @@ class SQLiteConsole(BasePlugin):
         if self.macros:
             # Insert code coming from the macro use itself (done now to avoid rendering troubles
             # when converting md 6> html after the macro content was inserted):
-            # To apply BEFORE using the old syntax logistic (relies on c.count value).god cod
+            # To apply BEFORE using the old syntax logistic (relies on c.count value).
             html = c.insert_macro_contents(html)
 
             # Still apply the "old way", for backward compatibility.


### PR DESCRIPTION
## FIXes pour la v2.0.1

* FIX - les sqlides dans les admonitions repliées `???` n'étaient pas rendues correctement quand le sqlide était créés via les macros.
* FIX - les pages mélangeant les deux types de syntaxes (macros + ancienne syntaxes) pouvaient se retrouver avec des IDE non fonctionnels car les worker des espaces communs étaient insérés lors de la première insertions d'un "espace" sql, mais l'ordre des générations de code pouvait ne pas suivre l'ordre de lecture dans la page : toutes les macros d'abord, puis une seconde passe est faite pour les anciennes syntaxes.


## Changements effectués :

* Changement de signature pour la macro, pour pouvoir utiliser qqes  arguments positionnels, pour alléger les déclarations.

* Les macros insèrent maintenant un token dans la page, qui sera remplacé par du code html durant `on_page_content` (évite les problèmes de conversion md -> html de mkdocs -> FIX 1)

* Les `workerinit` sont ajoutés via `on_page_context`, juste sous les scripts et le css liés au sql du plugin, pour garantir qu'ils seront toujours dispo avant les sqlide de la page (FIX 2).

* Ajout de qqes commentaires ici et là dans le code, car la logique devient plus complexe...


## MAJ docs pour v2.0.1 (+ qqes modifs cosmétiques)

* Arguments de la macro
* Ajout d'explication pour hide et autoexec
 * Exemple alternatif (arguments positionnels)

---

## NOTA :

Il semble que la remarque sur le bug dans les admonitions repliées n'est plus d'actualité => à virer ? (je n'ai rien remarqué, mais juste au cas où, je n'ai pas fait la modif)