### PR TITLE
FIX x2

### DIFF
--- a/docs/essai/code.sql
+++ b/docs/essai/code.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM employees;
+
+SELECT COUNT(*) FROM employees;

--- a/docs/essai/init1.sql
+++ b/docs/essai/init1.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS employees;
+CREATE TABLE employees
+(
+    id          integer,
+    name        text,
+    designation text,
+    manager     integer,
+    hired_on    date,
+    salary      integer,
+    commission  float,
+    dept        integer
+);
+
+INSERT INTO employees VALUES (1,'JOHNSON','ADMIN',6,'1990-12-17',18000,NULL,4);
+INSERT INTO employees VALUES (2,'HARDING','MANAGER',9,'1998-02-02',52000,300,3);
+INSERT INTO employees VALUES (3,'TAFT','SALES I',2,'1996-01-02',25000,500,3);
+INSERT INTO employees VALUES (4,'HOOVER','SALES I',2,'1990-04-02',27000,NULL,3);
+INSERT INTO employees VALUES (5,'LINCOLN','TECH',6,'1994-06-23',22500,1400,4);
+INSERT INTO employees VALUES (6,'GARFIELD','MANAGER',9,'1993-05-01',54000,NULL,4);

--- a/docs/essai/meh.md
+++ b/docs/essai/meh.md
@@ -1,5 +1,15 @@
 _(cette page n'est pas rendue sur le site, par défaut. L'activer via mkdocs.yml pour tester les chemins relatifs au fichier md en cours)_
 
-{{ sqlide titre="IDE avec initialisation et code pré-saisi" init="init1.sql" sql="code.sql" }}
+{!{ sqlide titre="IDE avec initialisation et code pré-saisi" init="init1.sql" sql="code.sql" }!}
 
-{{ sqlide titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté" base="../bases/test.db" sql="../sql/code.sql" autoexec}}
+{!{ sqlide titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté" base="../bases/test.db" sql="../sql/code.sql" autoexec}!}
+
+
+=== "onglet 1"
+
+    {{ sqlide("IDE avec initialisation et code pré-saisi", init="init1.sql", sql="code.sql") }}
+
+
+=== "onglet 2"
+
+    {{ sqlide("IDE avec initialisation et code pré-saisi", init="init1.sql", sql="code.sql") }}

--- a/docs/essai/meh.md
+++ b/docs/essai/meh.md
@@ -1,0 +1,5 @@
+_(cette page n'est pas rendue sur le site, par défaut. L'activer via mkdocs.yml pour tester les chemins relatifs au fichier md en cours)_
+
+{{ sqlide titre="IDE avec initialisation et code pré-saisi" init="init1.sql" sql="code.sql" }}
+
+{{ sqlide titre="IDE avec une base binaire chargée et code pré-saisi autoexécuté" base="../bases/test.db" sql="../sql/code.sql" autoexec}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,12 @@ nav:
         - 'License': 'licence.md'
         - 'Historique des versions': 'notes-de-version.md'
 
+    # - essai: 'essai/meh.md'   # testing purpose
+
+exclude_docs: |   # Désactiver tout le bloc pour activer dans la nav
+    essai/**
+
+
 repo_url: https://github.com/epithumia/mkdocs-sqlite-console
 site_url: https://epithumia.github.io/mkdocs-sqlite-console
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ nav:
         - 'Historique des versions': 'notes-de-version.md'
 
     # - essai: 'essai/meh.md'   # testing purpose
-
 exclude_docs: |   # Désactiver tout le bloc pour activer dans la nav
     essai/**
 
@@ -36,3 +35,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - attr_list
+  - pymdownx.tabbed: # Volets glissants.  === "Mon volet"
+      alternate_style: true   # compatibilité pour mobiles
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower

--- a/mkdocs_sqlite_console/js/material-tabbed-fix.js
+++ b/mkdocs_sqlite_console/js/material-tabbed-fix.js
@@ -1,0 +1,26 @@
+/**FIX rendering troubles for sqlides that are in secondary tabs. */
+(function(){
+
+  const delayedRefreshFactory = (content) =>()=>{
+    setTimeout(()=>{
+      const cms = Object.values(content.getElementsByClassName("CodeMirror"))
+      for(const elt of cms){
+        if(!elt.CodeMirror || !elt.CodeMirror.refresh){
+          continue
+        }
+        elt.CodeMirror.refresh()
+      }
+    })
+  }
+
+  const tabbed = Object.values(document.getElementsByClassName('tabbed-labels'))
+
+  for(const tab of tabbed){
+    const labels = Object.values(tab.getElementsByTagName("label"))
+    for(const label of labels){
+      const iLabel = [...label.parentElement.children].indexOf(label)
+      const content = tab.parentElement.getElementsByClassName("tabbed-content")[0].children[iLabel]
+      label.addEventListener("click", delayedRefreshFactory(content), {once:true})
+    }
+  }
+})()

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -143,7 +143,6 @@ class Counter:
         return a default message.
         """
         docs = self.config["docs_dir"]
-        path = rel_path     # default
 
         candidates_uris_srcs = [
             f"{ docs }/{ Path(page.file.src_uri).parent.as_posix() }",      # Relative to current page
@@ -164,7 +163,7 @@ class Counter:
                     content = f.read().replace('\n','')
             return True, content, path
 
-        return False, f"{ header } { rel_path } introuvable.", path
+        return False, f"{ header } { rel_path } introuvable.", rel_path
 
     def register_macro_content(self, html_code):
         """

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 from mkdocs.exceptions import PluginError
 from mkdocs.plugins import BasePlugin
-from mkdocs.structure.files import File
+from mkdocs.structure.files import File, Files
 from mkdocs.structure.pages import Page
 from mkdocs.config.defaults import MkDocsConfig
 
@@ -220,15 +220,12 @@ class SQLiteConsole(BasePlugin):
 
         return config
 
-    def on_files(self, files, config):
-        files.append(
-            File("sqlite_ide.css", CSS_PATH, config["site_dir"] + "/css/", False)
-        )
-        files.append(File("sqlite_ide.js", JS_PATH, config["site_dir"] + "/js/", False))
-        files.append(
-            File("worker.sql-wasm.js", JS_PATH, config["site_dir"] + "/js/", False)
-        )
-        files.append(File("sql-wasm.wasm", JS_PATH, config["site_dir"] + "/js/", False))
+    def on_files(self, files:Files, config):
+        for folder in "css js".split():
+            for file in (Path(BASE_PATH) / folder).iterdir():
+                files.append(
+                    File(file.name, file.parent, config["site_dir"] + f"/{ folder }/", False)
+                )
         return files
 
     def on_pre_page(self, page, config, files):

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -289,7 +289,11 @@ class SQLiteConsole(BasePlugin):
 
         # Mutate the page content with all the required logistic if any:
         if sql_scripts:
-            page.content = sql_scripts + page.content
+            page.content = f"""\
+{ sql_scripts }
+{ page.content }
+<script src="{ base_url }/js/material-tabbed-fix.js"></script>
+"""
 
     def counter_for(self, page, *, set_counter: Counter = None) -> Optional[Counter]:
         key = page and page.url

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -160,7 +160,7 @@ class Counter:
                 content = '_dummy'
             else:
                 with open(path, 'r', encoding='utf-8') as f:
-                    content = f.read().replace('\n','')
+                    content = f.read()
             return True, content, path
 
         return False, f"{ header } { rel_path } introuvable.", rel_path

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -12,8 +12,6 @@ from mkdocs.config.defaults import MkDocsConfig
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 
-LIBS_PATH = BASE_PATH + "/libs/"
-
 CSS_PATH = BASE_PATH + "/css/"
 
 JS_PATH = BASE_PATH + "/js/"

--- a/mkdocs_sqlite_console/plugin.py
+++ b/mkdocs_sqlite_console/plugin.py
@@ -1,11 +1,13 @@
 import os
+from pathlib import Path
 import re
-from typing import Optional
+from typing import Optional, Tuple
 
 from mkdocs.exceptions import PluginError
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import File
 from mkdocs.structure.pages import Page
+from mkdocs.config.defaults import MkDocsConfig
 
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -15,6 +17,8 @@ LIBS_PATH = BASE_PATH + "/libs/"
 CSS_PATH = BASE_PATH + "/css/"
 
 JS_PATH = BASE_PATH + "/js/"
+
+ARG_PATTERN_TEMPLATE = "{}\\s*=\\s*[\"']?([^\\s\"']*)"
 
 
 # "{workerinit}" was the first line of the template: removed in version > 2.0.0.
@@ -39,35 +43,45 @@ MACROS_TEMPLATE = "MKDOCS_SQLITE_CONSOLE_IDE_{}"
 
 
 
+
+
+
+
 class Counter:
+
     def __init__(self, config):
+        self.ROOT_URI = Path(config['docs_dir']).as_posix()
         self.count = 0
-        self.config = config
+        self.config: MkDocsConfig = config
         self.spaces = {}
         self.macros_contents = {}
         self.worker_inits = []
 
-    def insert_ide(self, macro):
-        regex_titre = r".*?titre=\"(.*?)\""
-        regex_init = r".*?init=[\"\']?\b([^\s]*)\b"
-        regex_base = r".*?base=[\"\']?\b([^\s]*)\b"
-        regex_sql = r".*?sql=[\"\']?\b([^\s]*)\b"
-        regex_space = r".*?espace=[\"\']?\b([^\s]*)\b"
+    def insert_ide(self, page:Page):
+        def wrapped(matches):
 
-        params = str(macro.groups(0)[0])
+            regex_titre = r".*?titre\s*=\s*\"(.*?)\""
+            regex_init = ARG_PATTERN_TEMPLATE.format('init')
+            regex_base = ARG_PATTERN_TEMPLATE.format('base')
+            regex_sql = ARG_PATTERN_TEMPLATE.format('sql')
+            regex_space = ARG_PATTERN_TEMPLATE.format('espace')
 
-        titre = "".join(re.findall(regex_titre, params))
-        autoexec = "autoexec" in params
-        hide = "hide" in params
-        init = "".join(re.findall(regex_init, params))
-        base = "".join(re.findall(regex_base, params))
-        sql = "".join(re.findall(regex_sql, params))
-        space = "".join(re.findall(regex_space, params))
+            params = str(matches.groups(0)[0])
 
-        return self.build_sql(titre, autoexec, hide, init, base, sql, space)
+            titre = "".join(re.findall(regex_titre, params))
+            autoexec = "autoexec" in params
+            hide = "hide" in params
+            init = "".join(re.findall(regex_init, params))
+            base = "".join(re.findall(regex_base, params))
+            sql = "".join(re.findall(regex_sql, params))
+            space = "".join(re.findall(regex_space, params))
 
-    def build_sql(self, titre, autoexec, hide, init, base, sql, space):
+            return self.build_sql(titre, autoexec, hide, init, base, sql, space, page=page)
+        return wrapped
+
+    def build_sql(self, titre, autoexec, hide, init, base, sql, space, *, page:Page=None):
         self.count += 1
+        worker = ""
 
         # handle defaults (centralizing the logic in one single place):
         autoexec = True if autoexec else ""
@@ -78,7 +92,6 @@ class Counter:
         sql = sql or ""
         space = space or None
 
-        worker = ""
         if space:
             if space not in self.spaces:
                 self.spaces[space] = 0
@@ -90,37 +103,28 @@ class Counter:
             else:
                 self.spaces[space] += 1
                 worker = space
+
         if sql != "":
-            try:
-                with open(os.path.abspath(self.config["docs_dir"]) + "/" + sql) as f:
-                    sql = f.readlines()
-                    sql = "".join(sql)
-                    if autoexec:
-                        autoexec = sql
-                        autoexec = autoexec.replace("\n", "\\n")
-                        autoexec = autoexec.replace("'", "\\'")
-            except OSError:
-                sql = "Fichier '" + sql + "' introuvable"
+            ok, sql, _ = self.get_relative_file(page, sql, "Fichier")
+            if ok and autoexec:
+                autoexec = sql.replace("\n", "\\n").replace("'", "\\'")
+
         if init != "":
-            try:
-                with open(os.path.abspath(self.config["docs_dir"]) + "/" + init) as f:
-                    init = f.readlines()
-                    init = "".join(init)
-                    init = init.replace("\n", "\\n")
-                    init = init.replace("'", "\\'")
-            except OSError:
-                sql = "-- Fichier d'initialisation '" + init + "' introuvable"
-                init = ""
+            ok, init, _ = self.get_relative_file(page, init, "-- Fichier d'initialisation")
+            init = init.replace("\n", "\\n").replace("'", "\\'")
+            if not ok:
+                sql, init = init, ""
+
         if base != "/":
-            base_url = self.config["site_url"]
-            if os.path.isfile(os.path.abspath(self.config["docs_dir"]) + "/" + base):
-                base = base_url + "/" + base
-                base = base.replace("//", "/")
+            ok, nope, resolved_path = self.get_relative_file(page, base, "-- Fichier de base")
+            if ok:
+                base = Path(resolved_path).as_posix().replace(self.ROOT_URI, self.config['site_url'])
             else:
-                sql = "-- Fichier de base '" + base + "' introuvable"
+                sql = nope
                 init = ""
                 base = "/"
-        html = SKELETON.format(
+
+        ide_html = SKELETON.format(
             numide=self.count,
             title=titre,
             hide=hide,
@@ -131,7 +135,36 @@ class Counter:
             worker=worker,
             #workerinit=workerinit,      # Not inserted here anymore (version > 2.0.0)
         )
-        return html
+        return ide_html
+
+    def get_relative_file(self, page:Page, rel_path:str, header:str) -> Tuple[bool, str, str]:
+        """
+        Extract a file relative to the current markdown file or to the docs dir, or
+        return a default message.
+        """
+        docs = self.config["docs_dir"]
+        path = rel_path     # default
+
+        candidates_uris_srcs = [
+            f"{ docs }/{ Path(page.file.src_uri).parent.as_posix() }",      # Relative to current page
+            docs,                                                           # Relative to docs_dir
+        ]
+        for cnd in candidates_uris_srcs:
+            path_uri = f"{ cnd }/{ rel_path }"
+            path = os.path.normpath(os.path.abspath(path_uri))
+
+            if not os.path.isfile(path):
+                continue
+
+            if path.endswith('.db'):
+                # .db are not readable with utf-8, but no need of their content so no problem.
+                content = '_dummy'
+            else:
+                with open(path, 'r', encoding='utf-8') as f:
+                    content = f.read().replace('\n','')
+            return True, content, path
+
+        return False, f"{ header } { rel_path } introuvable.", path
 
     def register_macro_content(self, html_code):
         """
@@ -220,7 +253,7 @@ class SQLiteConsole(BasePlugin):
             regex = r"(?:^|\n)\s*?<p>\s*?{{\s*?sqlide.*?\s+?(.*?)\s*?}}</p>(?:\n|$)"
 
         if c:
-            html = re.sub(regex, c.insert_ide, html, flags=re.MULTILINE | re.DOTALL)
+            html = re.sub(regex, c.insert_ide(page), html, flags=re.MULTILINE | re.DOTALL)
 
         return html
 
@@ -287,6 +320,7 @@ class SQLiteConsole(BasePlugin):
         when using Pyodide-MkDocs-Theme).
         """
         # (actual default values are handled in Counter.build_sql)
-        c = self.counter_for(self.macros.page)
-        html_code = c.build_sql(titre, autoexec, hide, init, base, sql, espace)
+        page = self.macros.page
+        c = self.counter_for(page)
+        html_code = c.build_sql(titre, autoexec, hide, init, base, sql, espace, page=page)
         return c.register_macro_content(html_code)


### PR DESCRIPTION
* Correction du bug des retours à la ligne manquants dans les codes des sqlides.

* Ajout de logistique JS pour supporter les sqlides dans des onlgets mkdocs/material (`=== "onglet"`).  
Sur ce point, je ne suis pas certain de comment faire pour être sûr que le nouveau fichier js soit incorporé au plugin. ça marche en local, mais je n'ai pas retrouvé comment tu renseignes quels fichiers font partie du package ou pas.

* Suppression de `LIBS_PATH` (non utilisée)

* Abstraction des insertions de fichiers CSS et JS durant le build mkdocs : découverte et ajout automatique de tous les fichiers trouvés dans les sous-répertoires css et js.