### PR TITLE
MAJ docs

### DIFF
--- a/docs/extras/tablesort.js
+++ b/docs/extras/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+  var tables = document.querySelectorAll("article table:not([class])")
+  tables.forEach(function(table) {
+    new Tablesort(table)
+  })
+})

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,10 +57,13 @@ site_url: https://epithumia.github.io/mkdocs-sqlite-console
 On peut afficher une console/IDE SQLite grâce à la commande `{{ sqlide paramètres }}`. Cette commande accepte quatre paramètres, tous optionnels :
 
 - un `titre` : par exemple `titre="Exercice 1"`. Par défaut, le titre est "sql"
-- un chemin vers un script SQL d'initialisation, `init` : par exemple `init=sql/init.md`
-- un chemin vers une `base` SQLite : par exemple `bases/test.db`
 - un chemin vers un fichier de code `sql` pré-saisi dans l'IDE : par exemple `sql="sql/code.sql"`
+- un nom `espace`, qui permet de mettre la même base de données [en commun avec plusieurs ides](#base-partagee-entre-plusieurs-consoles).
+- un chemin vers un script SQL d'initialisation, `init` : par exemple `init=sql/init.sql`
+- un chemin vers une `base` SQLite : par exemple `bases/test.db`
 - si le mot clef `autoexec` est présent, alors le contenu de code sera exécuté comme si l'utilisateur avait cliqué le bouton
+- si le mot clef `hide` est présent, l'élément sera [masqué dans la page](#cacher-lide)
+
 
 !!! tip "Astuce"
     A part pour le titre, les apostrophes ou guillemets sont optionnels. Ainsi, `sql="sql/code.sql"`,
@@ -164,7 +167,7 @@ Par rapport à l'utilisation normale du plugin, il faut :
 - Ajouter les parenthèses autour des arguments,
 - Ajouter des virgules entre les arguments,
 - Les guillemets autour des valeurs des arguments sont alors indispensables.
-- Les arguments passés sous forme de chaînes de caractères seule, dans la syntaxe originale (`autoexec`, `hide`), doivent être passés sous forme de booléens. On peut aussi utiliser des entiers pour raccourcir les déclaration : `0` ou `1`.
+- Les arguments passés sous forme de chaînes de caractères seules dans la syntaxe originale (`autoexec`, `hide`) doivent être passés sous forme de booléens. On peut aussi utiliser des entiers pour raccourcir les déclarations : `0` ou `1`.
 
 ??? help "Signature exacte de la macro"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,13 +31,26 @@ plugins:
   # - macros          # Activer pour tester en local (Nota: à placer avant sqlite-console)
   - sqlite-console
 
+
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - extras/tablesort.js
+
 markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - tables
+  - pymdownx.arithmatex:
+      generic: true
   - attr_list
   - pymdownx.tabbed: # Volets glissants.  === "Mon volet"
       alternate_style: true   # compatibilité pour mobiles
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
Re,

J'ai amélioré un peu l'intégration côté PMT, du coup j'ai refait une passe sur la doc ici.

* des typos ici et là
* ajout de tous les arguments dans la section "paramètres"
* Activation de qqes fonctionnalités classiques de mkdocs, histoire de ne pas se demander "tiens... pourquoi ça ne marche pas, ce truc ?"
* close #4  

Pas besoin de publier une version, il y a juste les pages GH à mettre à jour.

++
Fred